### PR TITLE
Wait until mgr-components are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ Executing this command will run containers for:
 ./start-docker-containers.sh -p mgr-components
 ```
 
+Wait until they are available:
+
+```shell
+curl -w"\n\n" -sS --retry-all-errors --retry 10 -D - http://localhost:9901/admin/health
+curl -w"\n\n" -sS --retry-all-errors --retry 8 -D - http://localhost:9902/admin/health
+curl -w"\n\n" -sS --retry-all-errors --retry 8 -D - http://localhost:9903/admin/health
+```
+
 Adding a new application to `mgr-applications` will require following steps:
 
 * To expose your pre-defined variables to current terminal


### PR DESCRIPTION
## Purpose
It may take a few minutes until all mgr-components are available depending on the hardware.

## Approach
Execute curl with `--retry-all-errors` to wait until they are available.

## TODOS and Open Questions
- [x] Check logging: Using option `-D -`

## Learning
Don't expect high cpu and memory resources and fast spin up times.