### PR TITLE
MGRAPPS-81 - remove platform field from descriptor

### DIFF
--- a/descriptors/app-platform-minimal/descriptor.json
+++ b/descriptors/app-platform-minimal/descriptor.json
@@ -3,7 +3,6 @@
   "name": "app-platform-minimal",
   "version": "0.0.17-SNAPSHOT.2",
   "description": "Minimal FOLIO platform installation",
-  "platform": "base",
   "modules": [
     {
       "id": "mod-configuration-5.12.0",


### PR DESCRIPTION
## Purpose

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->
[MGRAPPS-81](https://folio-org.atlassian.net/browse/MGRAPPS-81) - Remove unused "platform" field from the application descriptor schema/examples
 ## Approach

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Remove unused "platform" field from the application descriptor
## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->
