### PR TITLE
Fix DB init owner for kong DB

### DIFF
--- a/docker/db/init.sql
+++ b/docker/db/init.sql
@@ -52,7 +52,7 @@ alter schema public owner to keycloak_rw;
 create database kong;
 \set kong_db_password `echo $KONG_DB_PASSWORD`
 create user kong_rw with password :'kong_db_password';
-alter database kong owner to keycloak_rw;
+alter database kong owner to kong_rw;
 grant connect on database kong to kong_rw;
 grant all privileges on database kong to kong_rw;
 \c kong


### PR DESCRIPTION
`kong` database needs to be owned by `kong_rw` not `keycloak_rw`

## Purpose

db init.sql incorrectly sets the owner for the `kong` database to be `keycloak_rw` instead of `kong_rw` causing kong bootstrap to fail